### PR TITLE
Change non-nullsafe tripledes package to a version that is nullsafe

### DIFF
--- a/lib/src/crypto/des.dart
+++ b/lib/src/crypto/des.dart
@@ -1,6 +1,6 @@
 //  Created by Crt Vavros, copyright © 2022 ZeroPass. All rights reserved.
 import 'dart:typed_data';
-import 'package:tripledes/tripledes.dart';
+import 'package:tripledes_nullsafety/tripledes_nullsafety.dart';
 import 'iso9797.dart';
 
 /// Implements DES encryption algorithm using CBC block cipher mode
@@ -15,9 +15,9 @@ class DESCipher {
   ///
   /// [key] length must be 8 bytes.
   /// [iv] length must be 8 bytes.
-  DESCipher({ required final Uint8List key, required final Uint8List iv }) {
+  DESCipher({required final Uint8List key, required final Uint8List iv}) {
     this.key = key;
-    this.iv  = iv;
+    this.iv = iv;
   }
 
   /// Returns current key
@@ -27,7 +27,7 @@ class DESCipher {
 
   /// Sets new key. The [key] length must be 8 bytes.
   set key(final Uint8List key) {
-    if(key.length != blockSize) {
+    if (key.length != blockSize) {
       throw ArgumentError.value(key, "key length should be $blockSize bytes");
     }
     _key = _bytesToDWordList(key);
@@ -41,7 +41,8 @@ class DESCipher {
   /// Sets new iv. The [iv] length must be 8 bytes.
   set iv(final Uint8List iv) {
     if (iv.length != blockSize) {
-      throw ArgumentError.value(iv, "invalid IV length should be $blockSize bytes");
+      throw ArgumentError.value(
+          iv, "invalid IV length should be $blockSize bytes");
     }
     _iv = _bytesToDWordList(iv);
   }
@@ -66,7 +67,7 @@ class DESCipher {
 
   // Returns encrypted [block]. The [block] size must be 8 bytes.
   Uint8List encryptBlock(final Uint8List block) {
-    if(block.length % blockSize != 0) {
+    if (block.length % blockSize != 0) {
       throw ArgumentError.value(block, "block size should be $blockSize bytes");
     }
     _bc.init(true, _key);
@@ -77,8 +78,9 @@ class DESCipher {
 
   // Returns decrypted [eblock].
   Uint8List decryptBlock(final Uint8List eblock) {
-    if(eblock.length % blockSize != 0) {
-      throw ArgumentError.value(eblock, "eblock size should be $blockSize bytes");
+    if (eblock.length % blockSize != 0) {
+      throw ArgumentError.value(
+          eblock, "eblock size should be $blockSize bytes");
     }
     _bc.init(false, _key);
     final wblock = _bytesToDWordList(eblock);
@@ -87,29 +89,29 @@ class DESCipher {
   }
 
   /// block should be list of 2 ints
-  void _processBlock(final List<int> block)
-  {
+  void _processBlock(final List<int> block) {
     _bc.processBlock(block, 0);
   }
 
   /// Encrypts/decrypts [data] using CBC block cipher mode.
-  Uint8List _process(final Uint8List data)
-  {
-    if(data.length % blockSize != 0) {
-      throw ArgumentError.value(data, "data size should be multiple of $blockSize bytes");
+  Uint8List _process(final Uint8List data) {
+    if (data.length % blockSize != 0) {
+      throw ArgumentError.value(
+          data, "data size should be multiple of $blockSize bytes");
     }
 
     List<int> pdata = List<int>.empty(growable: true);
     List<int> xord = _iv;
     final size = data.length / blockSize;
-    for( int i = 0; i < size; i++) {
-      final block = _bytesToDWordList(data.sublist(i * blockSize, i * blockSize + 8));
+    for (int i = 0; i < size; i++) {
+      final block =
+          _bytesToDWordList(data.sublist(i * blockSize, i * blockSize + 8));
 
       // copy current block - to be used for CBC xoring when decrypting
       List<int> pblock = List.from(block);
 
       // CBC
-      if(_bc.forEncryption) {
+      if (_bc.forEncryption) {
         // xor block with previous encrypted block
         _xorBlock(block, xord);
       }
@@ -118,9 +120,10 @@ class DESCipher {
       _processBlock(block);
 
       // CBC
-      if(_bc.forEncryption) {
+      if (_bc.forEncryption) {
         xord = block;
-      } else { // decryption
+      } else {
+        // decryption
         // xor block with previous encrypted block
         _xorBlock(block, xord);
         xord = pblock;
@@ -133,24 +136,25 @@ class DESCipher {
   }
 
   Uint8List _padOrRef(final Uint8List data, final bool padData) {
-    if(padData) {
+    if (padData) {
       return ISO9797.pad(data);
     }
     return data;
   }
 
   Uint8List _unpadOrRef(final Uint8List data, final bool unpadData) {
-    if(unpadData) {
+    if (unpadData) {
       return ISO9797.unpad(data);
     }
     return data;
   }
 
   void _xorBlock(final List<int> block, final List<int> xdata) {
-    if(block.length != xdata.length) {
-      throw ArgumentError.value(xdata, "invalid length pf data to xor block with");
+    if (block.length != xdata.length) {
+      throw ArgumentError.value(
+          xdata, "invalid length pf data to xor block with");
     }
-    for(int i = 0; i < block.length; i++) {
+    for (int i = 0; i < block.length; i++) {
       block[i] ^= xdata[i];
     }
   }
@@ -167,40 +171,39 @@ class DESCipher {
   static Uint8List _dwordListToBytes(final List<int> dwords) {
     final bytes = Uint8List(dwords.length * 4);
     final view = ByteData.view(bytes.buffer);
-    for (int i = 0; i < dwords.length;  i++) {
+    for (int i = 0; i < dwords.length; i++) {
       view.setInt32(i * 4, dwords[i], Endian.big);
     }
     return bytes;
   }
 }
 
-
-
 /// Implements Triple DES encryption algorithm using CBC block cipher mode
 class DESedeCipher extends DESCipher {
-
   static const blockSize = DESCipher.blockSize;
 
   /// Creates a [DESedeCipher] with [key] and initial vector [iv].
   ///
   /// [key] length must be 8, 16 or 24 bytes.
   /// [iv] length must be 8 bytes.
-  DESedeCipher({ required final Uint8List key, required final Uint8List iv }) :
-    super(key: key, iv: iv);
+  DESedeCipher({required final Uint8List key, required final Uint8List iv})
+      : super(key: key, iv: iv);
 
   /// Sets new key. [key] length must be 8, 16 or 24 bytes.
   @override
   set key(final Uint8List key) {
-    if(key.length % 8 != 0 || key.length > 24) {
+    if (key.length % 8 != 0 || key.length > 24) {
       throw ArgumentError.value(key, "key length should be 8, 16 or 24 bytes");
     }
 
     _key = DESCipher._bytesToDWordList(key);
-    if(key.length == 16) { // Keying option 2
+    if (key.length == 16) {
+      // Keying option 2
       _key += _key.sublist(0, 2);
     }
 
-    if(key.length == 8) { // Keying option 3
+    if (key.length == 8) {
+      // Keying option 3
       _key += _key.sublist(0, 2) + _key.sublist(0, 2);
     }
   }
@@ -226,23 +229,28 @@ class DESedeCipher extends DESCipher {
   }
 }
 
-
-
 /// Returns encrypted [data] using Triple DES encryption algorithm and CBD block cipher mode.
 ///
 /// The [data] if [padData] is set to false should be padded to the nearest multiple of 8.
 /// When [padData] is true, the [data] is padded according to the ISO/IEC 9797-1, padding method 2.
 // ignore: non_constant_identifier_names
-Uint8List DESedeEncrypt({ required final Uint8List key, required final Uint8List iv, required final Uint8List data, bool padData = true}) {
+Uint8List DESedeEncrypt(
+    {required final Uint8List key,
+    required final Uint8List iv,
+    required final Uint8List data,
+    bool padData = true}) {
   return DESedeCipher(key: key, iv: iv).encrypt(data, padData: padData);
 }
-
 
 /// Returns decrypted [data] using Triple DES encryption algorithm and CBD block cipher mode.
 ///
 /// The [data] if [padData] is set to false should be padded to the nearest multiple of 8.
 /// When [padData] is true, the [data] is padded according to the ISO/IEC 9797-1, padding method 2.
 // ignore: non_constant_identifier_names
-Uint8List DESedeDecrypt({ required final Uint8List key, required final Uint8List iv, required final Uint8List edata, bool paddedData = true}) {
+Uint8List DESedeDecrypt(
+    {required final Uint8List key,
+    required final Uint8List iv,
+    required final Uint8List edata,
+    bool paddedData = true}) {
   return DESedeCipher(key: key, iv: iv).decrypt(edata, paddedData: paddedData);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 name: dmrtd
 description: Dart implementation of ICAO Doc 9303 MRTD, created by ZeroPass
 
-version: 1.4.2
+version: 1.4.3
 
 environment:
   sdk: '>=2.17.1 <3.0.0'
@@ -17,7 +17,7 @@ dependencies:
   flutter_nfc_kit: '^3.1.0'
   logging: ^1.0.1
   meta: ^1.3.0
-  tripledes: ^2.1.0
+  tripledes_nullsafety: ^1.0.3
 
 dev_dependencies:
   flutter:      # needed for flutter_nfc_kit


### PR DESCRIPTION
This pull request changes the Triple DES dependency from [this one](https://pub.dev/packages/tripledes) (which is not null safe) to [this one](https://pub.dev/packages/tripledes_nullsafety).

~Also updated the code example to make use of `flutter_platform_widgets: ^2.0.0`. And thus the `PlatformTextButton` is replacing the `PlatformButton` in `main.dart` of the example.~

It also changes some of the code formatting to make it a bit more uniform and in line with Dart/Flutter code formatting principles.

I tested the example project on a Nokia 7.1, which works.