### PR TITLE
Fix Invalid Algorithm OID

### DIFF
--- a/lib/src/crypto/aa_pubkey.dart
+++ b/lib/src/crypto/aa_pubkey.dart
@@ -49,7 +49,7 @@ class AAPublicKey {
     }
 
     final tvAlgOID = TLV.decode(tvAlg.value);
-    if (tvAlg.tag.value != 0x06) { // OID
+    if (tvAlgOID.tag.value != 0x06) { // OID
       throw Exception(
         "Invalid Algorithm OID object tag=${tvAlgOID.tag.value.hex()}, expected tag=06"
       );


### PR DESCRIPTION
Parses AAPublicKey RSA, throws Invalid Algorithm OID object tag, please check