### PR TITLE
Fix birthdate conversion issue in EFDG11

### DIFF
--- a/lib/src/extension/uint8list_apis.dart
+++ b/lib/src/extension/uint8list_apis.dart
@@ -12,3 +12,15 @@ extension Uint8ListEncodeApis on Uint8List {
     return conv.hex.encoder.convert(this);
   }
 }
+
+extension Uint8ListDecodeApis on Uint8List {
+  DateTime toDate() {
+    // The date is in the format 'CCYYMMDD'
+    int century = ((this[0] >> 4) * 10 + (this[0] & 0x0F)) * 100;
+    int year = (this[1] >> 4) * 10 + (this[1] & 0x0F);
+    int month = (this[2] >> 4) * 10 + (this[2] & 0x0F);
+    int day = (this[3] >> 4) * 10 + (this[3] & 0x0F);
+
+    return DateTime(century + year, month, day);
+  }
+}

--- a/lib/src/lds/df1/efdg11.dart
+++ b/lib/src/lds/df1/efdg11.dart
@@ -86,14 +86,16 @@ class EfDG11 extends DataGroup {
     final tlv = TLV.fromBytes(content);
     if (tlv.tag != tag) {
       throw EfParseError(
-          "Invalid DG11 tag=${tlv.tag.hex()}, expected tag=${TAG.value.hex()}");
+        "Invalid DG11 tag=${tlv.tag.hex()}, expected tag=${TAG.value.hex()}",
+      );
     }
 
     final data = tlv.value;
     final tagListTag = TLV.decode(data);
     if (tagListTag.tag.value != TAG_LIST_TAG) {
       throw EfParseError(
-          "Invalid version object tag=${tagListTag.tag.value.hex()}, expected version object with tag=5c");
+        "Invalid version object tag=${tagListTag.tag.value.hex()}, expected version object with tag=5c",
+      );
     }
     var tagListLength = tlv.value.length;
     int tagListBytesRead = tagListTag.encodedLen;
@@ -113,7 +115,10 @@ class EfDG11 extends DataGroup {
           _otherNames.add(utf8.decode(uvtv.value));
           break;
         case FULL_DATE_OF_BIRTH_TAG:
-          _fullDateOfBirth = String.fromCharCodes(uvtv.value).parseDate();
+          _fullDateOfBirth =
+              uvtv.value.length == 4
+                  ? uvtv.value.toDate()
+                  : String.fromCharCodes(uvtv.value).parseDate();
           break;
         case PLACE_OF_BIRTH_TAG:
           _placeOfBirth.add(utf8.decode(uvtv.value));


### PR DESCRIPTION
Using Malaysia's passport, parsing the birthdate in EFDG11 is giving error. Upon checking, the value read is in Uint8List with 4 elements, which is a binary coded date. 
I am not entirely sure if all MRTD document's birthdates are binary coded, so I apply a length checking on the birthdate value. If it is 4 bytes (length of 4), then it is likely to be binary coded and therefore attempt to convert it accordingly. Otherwise, it will fallback to the original date conversion using String.fromCharCodes