### PR TITLE
Fix Late Initialized Error when retrieving firstName in MRZ (EFDG1)

### DIFF
--- a/lib/src/lds/mrz.dart
+++ b/lib/src/lds/mrz.dart
@@ -52,29 +52,48 @@ class MRZ {
 
   static int calculateCheckDigit(String checkString) {
     const charMap = {
-      "0" :  "0",  "1" :  "1",
-      "2" :  "2",  "3" :  "3",
-      "4" :  "4",  "5" :  "5",
-      "6" :  "6",  "7" :  "7",
-      "8" :  "8",  "9" :  "9",
-      "<" :  "0",  " " :  "0",
-      "A" : "10",  "B" : "11",
-      "C" : "12",  "D" : "13",
-      "E" : "14",  "F" : "15",
-      "G" : "16",  "H" : "17",
-      "I" : "18",  "J" : "19",
-      "K" : "20",  "L" : "21",
-      "M" : "22",  "N" : "23",
-      "O" : "24",  "P" : "25",
-      "Q" : "26",  "R" : "27",
-      "S" : "28",  "T" : "29",
-      "U" : "30",  "V" : "31",
-      "W" : "32",  "X" : "33",
-      "Y" : "34",  "Z" : "35"
+      "0": "0",
+      "1": "1",
+      "2": "2",
+      "3": "3",
+      "4": "4",
+      "5": "5",
+      "6": "6",
+      "7": "7",
+      "8": "8",
+      "9": "9",
+      "<": "0",
+      " ": "0",
+      "A": "10",
+      "B": "11",
+      "C": "12",
+      "D": "13",
+      "E": "14",
+      "F": "15",
+      "G": "16",
+      "H": "17",
+      "I": "18",
+      "J": "19",
+      "K": "20",
+      "L": "21",
+      "M": "22",
+      "N": "23",
+      "O": "24",
+      "P": "25",
+      "Q": "26",
+      "R": "27",
+      "S": "28",
+      "T": "29",
+      "U": "30",
+      "V": "31",
+      "W": "32",
+      "X": "33",
+      "Y": "34",
+      "Z": "35",
     };
 
     var sum = 0;
-    var m   = 0;
+    var m = 0;
     const multipliers = [7, 3, 1];
     for (int i = 0; i < checkString.length; i++) {
       final lookup = charMap[checkString[i]];
@@ -114,14 +133,20 @@ class MRZ {
     _optData = _read(istream, 15);
     dateOfBirth = _readDate(istream, futureDate: false);
 
-    _assertCheckDigit(dateOfBirth.formatYYMMDD(), _readCD(istream),
-        "Data of Birth check digit mismatch");
+    _assertCheckDigit(
+      dateOfBirth.formatYYMMDD(),
+      _readCD(istream),
+      "Data of Birth check digit mismatch",
+    );
 
     gender = _read(istream, 1);
     dateOfExpiry = _readDate(istream, futureDate: true);
 
-    _assertCheckDigit(dateOfExpiry.formatYYMMDD(), _readCD(istream),
-        "Data of Expiry check digit mismatch");
+    _assertCheckDigit(
+      dateOfExpiry.formatYYMMDD(),
+      _readCD(istream),
+      "Data of Expiry check digit mismatch",
+    );
 
     nationality = _read(istream, 3);
     _optData2 = _read(istream, 11);
@@ -152,13 +177,19 @@ class MRZ {
 
     nationality = _read(istream, 3);
     dateOfBirth = _readDate(istream, futureDate: false);
-    _assertCheckDigit(dateOfBirth.formatYYMMDD(), _readCD(istream),
-        "Data of Birth check digit mismatch");
+    _assertCheckDigit(
+      dateOfBirth.formatYYMMDD(),
+      _readCD(istream),
+      "Data of Birth check digit mismatch",
+    );
 
     gender = _read(istream, 1);
     dateOfExpiry = _readDate(istream, futureDate: true);
-    _assertCheckDigit(dateOfExpiry.formatYYMMDD(), _readCD(istream),
-        "Data of Expiry check digit mismatch");
+    _assertCheckDigit(
+      dateOfExpiry.formatYYMMDD(),
+      _readCD(istream),
+      "Data of Expiry check digit mismatch",
+    );
 
     _optData = _read(istream, 7);
     _parseExtendedDocumentNumber(cdDocNum);
@@ -182,21 +213,33 @@ class MRZ {
 
     _docNum = _read(istream, 9);
     _assertCheckDigit(
-        _docNum, _readCD(istream), "Document Number check digit mismatch");
+      _docNum,
+      _readCD(istream),
+      "Document Number check digit mismatch",
+    );
 
     nationality = _read(istream, 3);
     dateOfBirth = _readDate(istream, futureDate: false);
-    _assertCheckDigit(dateOfBirth.formatYYMMDD(), _readCD(istream),
-        "Data of Birth check digit mismatch");
+    _assertCheckDigit(
+      dateOfBirth.formatYYMMDD(),
+      _readCD(istream),
+      "Data of Birth check digit mismatch",
+    );
 
     gender = _read(istream, 1);
     dateOfExpiry = _readDate(istream, futureDate: true);
-    _assertCheckDigit(dateOfExpiry.formatYYMMDD(), _readCD(istream),
-        "Data of Expiry check digit mismatch");
+    _assertCheckDigit(
+      dateOfExpiry.formatYYMMDD(),
+      _readCD(istream),
+      "Data of Expiry check digit mismatch",
+    );
 
     _optData = _read(istream, 14);
     _assertCheckDigit(
-        _optData, _readCD(istream), "Optional data check digit mismatch");
+      _optData,
+      _readCD(istream),
+      "Optional data check digit mismatch",
+    );
 
     final cdComposite = _readCD(istream);
 
@@ -216,6 +259,8 @@ class MRZ {
     }
     if (nameIds.length > 1) {
       firstName = nameIds.sublist(1).join(' ');
+    } else {
+      firstName = '';
     }
   }
 
@@ -233,7 +278,10 @@ class MRZ {
     }
 
     _assertCheckDigit(
-        _docNum, cdDocNum, "Document Number check digit mismatch");
+      _docNum,
+      cdDocNum,
+      "Document Number check digit mismatch",
+    );
   }
 
   static String _read(InputStream istream, int maxLength) {


### PR DESCRIPTION
Not all passports have first name in EFDG1 (MRZ data), which gives late initialized error. Quick fix by returning empty string when firstName is not available.