### PR TITLE
 AES key length is not equal to AES block size

### DIFF
--- a/lib/src/proto/pace.dart
+++ b/lib/src/proto/pace.dart
@@ -544,7 +544,7 @@ class PACE {
 
     if (cipherAlgorithm == CipherAlgorithm.AES) {
       _log.debug("Cipher algorithm: AES.");
-      AESCipher aesCipher = AESChiperSelector.getChiper(size: KEY_LENGTH.s128); //size is not important
+      AESCipher aesCipher = AESChiperSelector.getChiper(size: keyLength);
       Uint8List computedAuthToken = aesCipher.calculateCMAC(data: inputData, key: macKey);
       _log.sdVerbose("Computed auth token: ${computedAuthToken.hex()}");
       return computedAuthToken;
@@ -580,8 +580,8 @@ class PACE {
 
       if (cipherAlgo == CipherAlgorithm.AES){
         _log.debug("PACE.decryptNonce; Cipher algorithm: AES");
-        AESCipher aesCipher128 = AESChiperSelector.getChiper(size: KEY_LENGTH.s128);
-        Uint8List decryptedNonce = aesCipher128.decrypt(data: nonce, key: k_pi);
+        AESCipher aesCipher = AESChiperSelector.getChiper(size: keyLength);
+        Uint8List decryptedNonce = aesCipher.decrypt(data: nonce, key: k_pi);
         _log.sdVerbose("PACE.decryptNonce; Decrypted nonce: ${decryptedNonce.hex()}");
         return decryptedNonce;
       }

--- a/test/pace_aes_256_test.dart
+++ b/test/pace_aes_256_test.dart
@@ -1,0 +1,45 @@
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:dmrtd/extensions.dart';
+
+import 'package:dmrtd/src/proto/pace.dart';
+import 'package:dmrtd/src/lds/asn1ObjectIdentifiers.dart';
+import 'package:dmrtd/src/proto/access_key.dart';
+import 'package:dmrtd/src/crypto/aes.dart';
+
+class _DummyAccessKey extends AccessKey {
+  @override
+  int PACE_REF_KEY_TAG = 0x00;
+
+  final Uint8List _kpi;
+  _DummyAccessKey(this._kpi);
+
+  @override
+  Uint8List Kpi(CipherAlgorithm cipherAlgorithm, KEY_LENGTH keyLength) => _kpi;
+
+  @override
+  String toString() => 'DummyAccessKey{Kpi:${_kpi.hex()}}';
+}
+
+void main() {
+  test('decryptNonce accepts AES key length different from block size', () {
+    final paceProtocolMap = customOIDS.firstWhere(
+        (e) => e['readableName'] == 'id-PACE-ECDH-GM-AES-CBC-CMAC-256');
+    final paceProtocol = OIEPaceProtocol.fromMap(item: paceProtocolMap);
+
+    final kpi =
+        '00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF'
+            .parseHex();
+    final nonce = 'A1A2A3A4A5A6A7A8A9AAABACADAEAFB0'.parseHex();
+
+    final aes = AESChiperSelector.getChiper(size: KEY_LENGTH.s256);
+    final encrypted = aes.encrypt(data: nonce, key: kpi);
+
+    final accessKey = _DummyAccessKey(kpi);
+    final decrypted = PACE.decryptNonce(
+        paceProtocol: paceProtocol, nonce: encrypted, accessKey: accessKey);
+
+    expect(decrypted, nonce);
+  });
+}


### PR DESCRIPTION
Dutch Passports have a AES256 bit key length. The assumption that the block size which is always 16 bytes (128 bits) with AES is also the key length is simply incorrect. This PR fixes #31 on your side but sadly [the same issue](https://github.com/bcgit/pc-dart/issues/200) is made in Pointy Castle. 


These are the errors people often encounter.
```
I/flutter ( 4922): pace FINE: 2025-07-09 14:13:43.293789: Cipher algorithm: AES, Key length: 256 bits
.
.
.
I/flutter ( 7239): pace SEVERE: 2025-07-09 10:25:13.240112: PACE.decryptNonce; Failed: AESCipher.decrypt; AES128 key length must be 128 bits.
I/flutter ( 7239): pace SEVERE: 2025-07-09 10:25:13.240874: PACE(1); Failed: PACE.decryptNonce; Failed: AESCipher.decrypt; AES128 key length must be 128 bits.
I/flutter ( 7239): pace SEVERE: 2025-07-09 10:25:13.241833: PACE key establishment failed: PACE(1); Failed: PACE.decryptNonce; Failed: AESCipher.decrypt; AES128 key length must be 128 bits.
I/flutter ( 7239): mrtdeg.app SEVERE: 2025-07-09 10:25:13.243160: An exception was encountered while trying to read Passport: PACE key establishment failed: PACE(1); Failed: PACE.decryptNonce; Failed: AESCipher.decrypt; AES128 key length must be 128 bits.
```